### PR TITLE
Create a new directory to hold the new plugin version when recompiling

### DIFF
--- a/module/plugin/create.go
+++ b/module/plugin/create.go
@@ -78,6 +78,9 @@ func createPlugin(id, body string) (string, error) {
 				return "", fmt.Errorf("error creating directory: %s", err)
 			}
 		}
+		else {
+			return "", fmt.Errorf("error creating directory: %s", err)
+		}
 	}
 
 	sourcePath := "./module/plugin/source/" + id + "/plugin.go"

--- a/module/plugin/create.go
+++ b/module/plugin/create.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
+	"math/rand"
 )
 
 type Module struct {
@@ -67,7 +69,15 @@ func createPlugin(id, body string) (string, error) {
 
 	err := os.Mkdir("./module/plugin/source/"+id, 0777)
 	if err != nil {
-		return "", fmt.Errorf("error creating directory: %s", err)
+		rand.Seed(time.Now().UnixNano())
+		if os.IsExist(err) {
+			new_path := fmt.Sprintf("./module/plugin/source/%s_%d", id, rand.Uint64())
+			os.Rename("./module/plugin/source/"+id, new_path)
+			err := os.Mkdir("./module/plugin/source/"+id, 0777)
+			if err != nil {
+				return "", fmt.Errorf("error creating directory: %s", err)
+			}
+		}
 	}
 
 	sourcePath := "./module/plugin/source/" + id + "/plugin.go"


### PR DESCRIPTION
I tend to get one compiler error that it will then fix, but it used to break when the directory already existed, so we move it beforehand.