### PR TITLE
GPT Model is now an enviroment variable

### DIFF
--- a/chat_loop.go
+++ b/chat_loop.go
@@ -3,14 +3,15 @@ package main
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/ian-kent/gptchat/config"
 	"github.com/ian-kent/gptchat/module"
 	"github.com/ian-kent/gptchat/parser"
 	"github.com/ian-kent/gptchat/ui"
 	"github.com/ian-kent/gptchat/util"
 	"github.com/sashabaranov/go-openai"
-	"strings"
-	"time"
 )
 
 func chatLoop(cfg config.Config) {
@@ -113,7 +114,7 @@ RESET:
 		resp, err := client.CreateChatCompletion(
 			context.Background(),
 			openai.ChatCompletionRequest{
-				Model:    openai.GPT4,
+				Model:    cfg.OpenAIAPIModel(),
 				Messages: conversation,
 			},
 		)

--- a/config/config.go
+++ b/config/config.go
@@ -1,7 +1,8 @@
 package config
 
 type Config struct {
-	openaiAPIKey string
+	openaiAPIKey   string
+	openaiAPIModel string
 
 	supervisedMode bool
 	debugMode      bool
@@ -10,9 +11,14 @@ type Config struct {
 func New() Config {
 	return Config{
 		openaiAPIKey:   "",
+		openaiAPIModel: "",
 		supervisedMode: true,
 		debugMode:      false,
 	}
+}
+
+func (c Config) OpenAIAPIModel() string {
+	return c.openaiAPIModel
 }
 
 func (c Config) OpenAIAPIKey() string {
@@ -39,5 +45,10 @@ func (c Config) WithSupervisedMode(supervisedMode bool) Config {
 
 func (c Config) WithDebugMode(debugMode bool) Config {
 	c.debugMode = debugMode
+	return c
+}
+
+func (c Config) WithOpenAIAPIModel(apiModel string) Config {
+	c.openaiAPIModel = apiModel
 	return c
 }

--- a/main.go
+++ b/main.go
@@ -2,15 +2,16 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
 	"github.com/ian-kent/gptchat/config"
 	"github.com/ian-kent/gptchat/module"
 	"github.com/ian-kent/gptchat/module/memory"
 	"github.com/ian-kent/gptchat/module/plugin"
 	"github.com/ian-kent/gptchat/ui"
 	openai "github.com/sashabaranov/go-openai"
-	"os"
-	"strconv"
-	"strings"
 )
 
 var client *openai.Client
@@ -21,7 +22,7 @@ func init() {
 	if openaiAPIKey == "" {
 		ui.Warn("You haven't configured an OpenAI API key")
 		fmt.Println()
-		if !ui.PromptConfirm("Do you have an API key with access to the GPT-4 model?") {
+		if !ui.PromptConfirm("Do you have an API key?") {
 			ui.Warn("You'll need an API key to use GPTChat")
 			fmt.Println()
 			fmt.Println("* You can get an API key at https://platform.openai.com/account/api-keys")
@@ -38,6 +39,16 @@ func init() {
 	}
 
 	cfg = cfg.WithOpenAIAPIKey(openaiAPIKey)
+
+	openaiAPIModel := strings.TrimSpace(os.Getenv("OPENAI_API_MODEL"))
+
+	if openaiAPIModel == "" {
+		ui.Warn("You haven't configured an OpenAI API model, defaulting to GPT4")
+
+		openaiAPIModel = openai.GPT4
+	}
+
+	cfg = cfg.WithOpenAIAPIModel(openaiAPIModel)
 
 	supervisorMode := os.Getenv("GPTCHAT_SUPERVISOR")
 	switch strings.ToLower(supervisorMode) {
@@ -71,8 +82,8 @@ func init() {
 
 func main() {
 	ui.Welcome(
-		`Welcome to the GPT-4 client.`,
-		`You can talk directly to GPT-4, or you can use /commands to interact with the client.
+		`Welcome to the GPT client.`,
+		`You can talk directly to GPT, or you can use /commands to interact with the client.
 
 Use /help to see a list of available commands.`)
 

--- a/module/memory/memory.go
+++ b/module/memory/memory.go
@@ -39,7 +39,7 @@ func (m *Module) Execute(args, body string) (string, error) {
 	case "store":
 		return m.Store(body)
 	case "recall":
-		return m.Recall(body, m.cfg.OpenAIAPIModel())
+		return m.Recall(body)
 	default:
 		return "", errors.New(fmt.Sprintf("command not implemented: /memory %s", args))
 	}

--- a/module/memory/memory.go
+++ b/module/memory/memory.go
@@ -3,6 +3,7 @@ package memory
 import (
 	"errors"
 	"fmt"
+
 	"github.com/ian-kent/gptchat/config"
 	"github.com/ian-kent/gptchat/util"
 	openai "github.com/sashabaranov/go-openai"
@@ -38,7 +39,7 @@ func (m *Module) Execute(args, body string) (string, error) {
 	case "store":
 		return m.Store(body)
 	case "recall":
-		return m.Recall(body)
+		return m.Recall(body, m.cfg.OpenAIAPIModel())
 	default:
 		return "", errors.New(fmt.Sprintf("command not implemented: /memory %s", args))
 	}

--- a/module/memory/recall.go
+++ b/module/memory/recall.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sashabaranov/go-openai"
 )
 
-func (m *Module) Recall(input string, gptModel string) (string, error) {
+func (m *Module) Recall(input string) (string, error) {
 	b, err := json.Marshal(m.memories)
 	if err != nil {
 		return "", err
@@ -17,7 +17,7 @@ func (m *Module) Recall(input string, gptModel string) (string, error) {
 	resp, err := m.client.CreateChatCompletion(
 		context.Background(),
 		openai.ChatCompletionRequest{
-			Model: gptModel,
+			Model: m.cfg.OpenAIAPIModel(),
 			Messages: []openai.ChatCompletionMessage{
 				{
 					Role: openai.ChatMessageRoleSystem,

--- a/module/memory/recall.go
+++ b/module/memory/recall.go
@@ -3,11 +3,12 @@ package memory
 import (
 	"context"
 	"encoding/json"
+
 	"github.com/ian-kent/gptchat/util"
 	"github.com/sashabaranov/go-openai"
 )
 
-func (m *Module) Recall(input string) (string, error) {
+func (m *Module) Recall(input string, gptModel string) (string, error) {
 	b, err := json.Marshal(m.memories)
 	if err != nil {
 		return "", err
@@ -16,7 +17,7 @@ func (m *Module) Recall(input string) (string, error) {
 	resp, err := m.client.CreateChatCompletion(
 		context.Background(),
 		openai.ChatCompletionRequest{
-			Model: openai.GPT4,
+			Model: gptModel,
 			Messages: []openai.ChatCompletionMessage{
 				{
 					Role: openai.ChatMessageRoleSystem,


### PR DESCRIPTION
Solves #9

In order to use GPT-3.5, define the env var OPENAI_API_MODEL as "gpt-3.5-turbo"
Defaults to GPT-4