### PR TITLE
Add GPTCHAT_THEME environment variable

### DIFF
--- a/ui/theme.go
+++ b/ui/theme.go
@@ -1,0 +1,57 @@
+package ui
+
+import (
+	"os"
+	"strings"
+
+	"github.com/fatih/color"
+)
+
+var theme Theme
+
+func init() {
+	if strings.ToUpper(os.Getenv("GPTCHAT_THEME")) == "DARK" {
+		theme = DarkTheme
+	} else {
+		theme = LightTheme
+	}
+}
+
+type Theme struct {
+	Username *color.Color
+	Message  *color.Color
+	Useful   *color.Color
+	AI       *color.Color
+	User     *color.Color
+	Info     *color.Color
+	Error    *color.Color
+	Warn     *color.Color
+	App      *color.Color
+	AppBold  *color.Color
+}
+
+var LightTheme = Theme{
+	Username: color.New(color.FgRed),
+	Message:  color.New(color.FgBlue),
+	Useful:   color.New(color.FgWhite),
+	AI:       color.New(color.FgGreen),
+	User:     color.New(color.FgYellow),
+	Info:     color.New(color.FgWhite, color.Bold),
+	Error:    color.New(color.FgHiRed, color.Bold),
+	Warn:     color.New(color.FgHiYellow, color.Bold),
+	App:      color.New(color.FgWhite),
+	AppBold:  color.New(color.FgGreen, color.Bold),
+}
+
+var DarkTheme = Theme{
+	Username: color.New(color.FgRed),
+	Message:  color.New(color.FgBlue),
+	Useful:   color.New(color.FgBlack),
+	AI:       color.New(color.FgGreen),
+	User:     color.New(color.FgMagenta),
+	Info:     color.New(color.FgBlack, color.Bold),
+	Error:    color.New(color.FgHiRed, color.Bold),
+	Warn:     color.New(color.FgHiMagenta, color.Bold),
+	App:      color.New(color.FgBlack),
+	AppBold:  color.New(color.FgGreen, color.Bold),
+}

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -3,24 +3,8 @@ package ui
 import (
 	"bufio"
 	"fmt"
-	"github.com/fatih/color"
 	"os"
 	"strings"
-)
-
-var (
-	cUsername = color.New(color.FgRed)
-	cMessage  = color.New(color.FgBlue)
-	cUseful   = color.New(color.FgWhite)
-	cAI       = color.New(color.FgGreen)
-	cUser     = color.New(color.FgYellow)
-
-	cInfo  = color.New(color.FgWhite, color.Bold)
-	cError = color.New(color.FgHiRed, color.Bold)
-	cWarn  = color.New(color.FgHiYellow, color.Bold)
-
-	cApp     = color.New(color.FgWhite)
-	cAppBold = color.New(color.FgGreen, color.Bold)
 )
 
 const (
@@ -34,41 +18,41 @@ const (
 )
 
 func Error(message string, err error) {
-	cError.Printf("ERROR: ")
-	cUseful.Printf("%s: %v\n\n", message, err)
+	theme.Error.Printf("ERROR: ")
+	theme.Useful.Printf("%s: %v\n\n", message, err)
 }
 
 func Warn(message string) {
-	cWarn.Printf("WARNING: ")
-	cUseful.Printf("%s\n", message)
+	theme.Warn.Printf("WARNING: ")
+	theme.Useful.Printf("%s\n", message)
 }
 
 func Info(message string) {
-	cWarn.Printf("INFO: ")
-	cUseful.Printf("%s\n", message)
+	theme.Warn.Printf("INFO: ")
+	theme.Useful.Printf("%s\n", message)
 }
 
 func Welcome(title, message string) {
-	cAppBold.Printf("%s\n\n", title)
-	cApp.Printf("%s\n\n", message)
+	theme.AppBold.Printf("%s\n\n", title)
+	theme.App.Printf("%s\n\n", message)
 }
 
 func PrintChatDebug(name, message string) {
-	cUseful.Printf("[DEBUG] ")
+	theme.Useful.Printf("[DEBUG] ")
 	PrintChat(name, message)
 }
 
 func PrintChat(name, message string) {
 	switch name {
 	case User:
-		cUser.Printf("%s:\n\n", name)
-		cMessage.Printf("%s\n", indent(message))
+		theme.User.Printf("%s:\n\n", name)
+		theme.Message.Printf("%s\n", indent(message))
 	case AI:
-		cAI.Printf("%s:\n\n", name)
-		cUseful.Printf("%s\n", indent(message))
+		theme.AI.Printf("%s:\n\n", name)
+		theme.Useful.Printf("%s\n", indent(message))
 	case App:
-		cAppBold.Printf("%s:\n\n", name)
-		cUseful.Printf("%s\n", indent(message))
+		theme.AppBold.Printf("%s:\n\n", name)
+		theme.Useful.Printf("%s\n", indent(message))
 	case System:
 		fallthrough
 	case Tool:
@@ -78,14 +62,14 @@ func PrintChat(name, message string) {
 	case Module:
 		fallthrough
 	default:
-		cUsername.Printf("%s:\n\n", name)
-		cMessage.Printf("%s\n", indent(message))
+		theme.Username.Printf("%s:\n\n", name)
+		theme.Message.Printf("%s\n", indent(message))
 	}
 }
 
 func PromptChatInput() string {
 	reader := bufio.NewReader(os.Stdin)
-	cUser.Printf("USER:\n\n    ")
+	theme.User.Printf("USER:\n\n    ")
 	text, _ := reader.ReadString('\n')
 	text = strings.TrimSpace(text)
 	fmt.Println()
@@ -95,7 +79,7 @@ func PromptChatInput() string {
 
 func PromptConfirm(prompt string) bool {
 	reader := bufio.NewReader(os.Stdin)
-	cAppBold.Printf("%s [Y/N]: ", prompt)
+	theme.AppBold.Printf("%s [Y/N]: ", prompt)
 	text, _ := reader.ReadString('\n')
 	text = strings.TrimSpace(text)
 	fmt.Println()
@@ -105,7 +89,7 @@ func PromptConfirm(prompt string) bool {
 
 func PromptInput(prompt string) string {
 	reader := bufio.NewReader(os.Stdin)
-	cAppBold.Printf("%s ", prompt)
+	theme.AppBold.Printf("%s ", prompt)
 	text, _ := reader.ReadString('\n')
 	text = strings.TrimSpace(text)
 	return text


### PR DESCRIPTION
I use a solarized theme in my terminal and the light colors are impossible to read:

![image](https://github.com/ian-kent/gptchat/assets/943597/e1d8b2d2-dc3e-4804-8e5c-23f5fee797e0)

This PR adds a `GPTCHAT_THEME` env variable which lets you switch to a dark theme.

![image](https://github.com/ian-kent/gptchat/assets/943597/50d4a5e1-b526-443e-8f45-89b919518737)

